### PR TITLE
Move and alter Clocks struct to match stm32f30x_hal reference crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stm32l4x6-hal"
-version = "0.0.7"
+version = "0.1.0"
 authors = ["Douman <douman@gmx.se>"]
 keywords = ["arm", "cortex-m", "stm32", "hal", "embedded-hal"]
 description = "HAL for the STM32L4x6 family of microcontrollers"
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 
 [dependencies]
 cortex-m = "0.4"
-embedded-hal = "0.1.0"
+embedded-hal = "0.1.2"
 nb = "0.1.0"
 stm32l4x6 = "0"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use cortex_m::peripheral::syst::SystClkSource;
 
 use ::cmp;
 
-use time::{Clocks};
+use rcc::{Clocks};
 
 ///Max possible value to set on SYST's RVR register.
 ///
@@ -29,10 +29,11 @@ pub trait SysClockConfig {
 
 impl SysClockConfig for SYST {
     fn set_reload_us(&mut self, us: u32, clocks: &Clocks) {
-        let rvr = us * (clocks.sys.0 / 1_000_000);
+        let rvr = us * (clocks.sysclk.0 / 1_000_000);
         let rvr = cmp::min(rvr, SYST_MAX_RVR);
 
         self.set_clock_source(SystClkSource::Core);
         self.set_reload(rvr);
     }
 }
+

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -7,7 +7,7 @@ use hal::blocking::delay::{DelayMs, DelayUs};
 
 use ::cmp;
 
-use time::Clocks;
+use rcc::Clocks;
 use config::SYST_MAX_RVR;
 
 /// System timer (SysTick) as a delay provider
@@ -50,7 +50,7 @@ impl DelayMs<u8> for Delay {
 
 impl DelayUs<u32> for Delay {
     fn delay_us(&mut self, us: u32) {
-        let mut total_rvr = us * (self.clocks.sys.0 / 1_000_000);
+        let mut total_rvr = us * (self.clocks.sysclk.0 / 1_000_000);
 
         while total_rvr != 0 {
             let current_rvr = cmp::min(total_rvr, SYST_MAX_RVR);

--- a/src/time.rs
+++ b/src/time.rs
@@ -32,22 +32,3 @@ impl Into<KiloHertz> for MegaHertz {
         KiloHertz(self.0 * 1_000)
     }
 }
-
-/// Frozen clock frequencies
-///
-/// The existence of this value indicates that the clock configuration can no longer be changed
-#[derive(Clone, Copy)]
-pub struct Clocks {
-    ///Frequency of AHB bus.
-    pub ahb: Hertz,
-    ///Frequency of APB1 bus.
-    pub apb1: Hertz,
-    ///APB1's prescaler
-    pub ppre1: u8,
-    ///Frequency of APB2 bus.
-    pub apb2: Hertz,
-    ///APB2's prescaler
-    pub ppre2: u8,
-    ///Frequency of System clocks.
-    pub sys: Hertz
-}

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -5,8 +5,8 @@ use hal::timer::{CountDown, Periodic};
 use nb;
 
 use config::SYST_MAX_RVR;
-use time::{Hertz, Clocks};
-use rcc::{APB1, APB2};
+use time::Hertz;
+use rcc::{APB1, APB2, Clocks};
 
 use cast::{u32, u16};
 
@@ -61,7 +61,7 @@ impl CountDown for Timer<SYST> {
     type Time = Hertz;
 
     fn start<T: Into<Hertz>>(&mut self, timeout: T) {
-        let rvr = self.clocks.sys.0 / timeout.into().0 - 1;
+        let rvr = self.clocks.sysclk.0 / timeout.into().0 - 1;
 
         assert!(rvr < SYST_MAX_RVR);
 
@@ -193,7 +193,7 @@ impl_timer!(
         alias: Tim1;
         constructor: tim1;
         APB2: {
-            apb: apb2;
+            apb: pclk2;
             enr: tim1en;
             rstr: tim1rst;
             ppre: ppre2
@@ -203,7 +203,7 @@ impl_timer!(
         alias: Tim8;
         constructor: tim8;
         APB2: {
-            apb: apb2;
+            apb: pclk2;
             enr: tim8en;
             rstr: tim8rst;
             ppre: ppre2
@@ -213,7 +213,7 @@ impl_timer!(
         alias: Tim2;
         constructor: tim2;
         APB1: {
-            apb: apb1;
+            apb: pclk1;
             enr1: tim2en;
             rstr1: tim2rst;
             ppre: ppre1
@@ -223,7 +223,7 @@ impl_timer!(
         alias: Tim3;
         constructor: tim3;
         APB1: {
-            apb: apb1;
+            apb: pclk1;
             enr1: tim3en;
             rstr1: tim3rst;
             ppre: ppre1
@@ -233,7 +233,7 @@ impl_timer!(
         alias: Tim4;
         constructor: tim4;
         APB1: {
-            apb: apb1;
+            apb: pclk1;
             enr1: tim4en;
             rstr1: tim4rst;
             ppre: ppre1
@@ -243,7 +243,7 @@ impl_timer!(
         alias: Tim5;
         constructor: tim5;
         APB1: {
-            apb: apb1;
+            apb: pclk1;
             enr1: tim5en;
             rstr1: tim5rst;
             ppre: ppre1
@@ -253,7 +253,7 @@ impl_timer!(
         alias: Tim15;
         constructor: tim15;
         APB2: {
-            apb: apb2;
+            apb: pclk2;
             enr: tim15en;
             rstr: tim15rst;
             ppre: ppre2
@@ -263,7 +263,7 @@ impl_timer!(
         alias: Tim16;
         constructor: tim16;
         APB2: {
-            apb: apb2;
+            apb: pclk2;
             enr: tim16en;
             rstr: tim16rst;
             ppre: ppre2
@@ -273,7 +273,7 @@ impl_timer!(
         alias: Tim17;
         constructor: tim17;
         APB2: {
-            apb: apb2;
+            apb: pclk2;
             enr: tim17en;
             rstr: tim17rst;
             ppre: ppre2
@@ -283,7 +283,7 @@ impl_timer!(
         alias: Tim6;
         constructor: tim6;
         APB1: {
-            apb: apb1;
+            apb: pclk1;
             enr1: tim6en;
             rstr1: tim6rst;
             ppre: ppre1
@@ -293,7 +293,7 @@ impl_timer!(
         alias: Tim7;
         constructor: tim7;
         APB1: {
-            apb: apb1;
+            apb: pclk1;
             enr1: tim7en;
             rstr1: tim7rst;
             ppre: ppre1


### PR DESCRIPTION
This is a small, but breaking, change that moves the `Clocks` struct out of `::time` and into `::rcc`, to more closely match the structure of the [stm32f30x_hal](https://docs.rs/stm32f30x-hal/0.1.2/stm32f30x_hal/rcc/struct.Clocks.html) crate. This will permit me to call `rcc.freeze(...)` and use the returned struct with any compliant `_hal` crate.