### PR TITLE
Add support for STM32L496AG

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
 script:
   - cargo check --target $TARGET
   - cargo check --target $TARGET --features STM32L476VG
+  - cargo check --target $TARGET --features STM32L496AG
 
 after_script: set +e
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,5 @@ STM32L476VG = []
 STM32L496AG = []
 
 [package.metadata.docs.rs]
-features = ["STM32L476VG", "STM32L496AG", "rt"]
+#features = ["STM32L476VG", "STM32L496AG", "rt"]
+features = ["STM32L476VG", "rt"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ version = "0"
 [features]
 rt = ["stm32l4x6/rt"]
 STM32L476VG = []
+STM32L496AG = []
 
 [package.metadata.docs.rs]
-features = ["STM32L476VG", "rt"]
+features = ["STM32L476VG", "STM32L496AG", "rt"]

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -381,10 +381,6 @@ impl_gpio!(C, GPIOC, gpiocen, gpiocrst,
 
 #[cfg(feature = "STM32L476VG")]
 pub mod stm32l476vg;
-#[cfg(feature = "STM32L476VG")]
-pub use gpio::stm32l476vg::gpio::*;
 
 #[cfg(feature = "STM32L496AG")]
 pub mod stm32l496ag;
-#[cfg(feature = "STM32L496AG")]
-pub use gpio::stm32l496ag::gpio::*;

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -1,7 +1,9 @@
 //! General Purpose Input / Output
 //!
-//! Note that GPIO layout is specific to board
-//! which is configured through features.
+//! This module provides common GPIO definitions that are available on all STM32L4x6 packages. By
+//! enabling features, you can use definitions for specific chips which may include additional
+//! GPIO lines. In that case, you will probably not want to `use` this module directly, but instead
+//! use it re-exported by the chip module.
 
 
 use ::ops::Deref;
@@ -381,3 +383,8 @@ impl_gpio!(C, GPIOC, gpiocen, gpiocrst,
 pub mod stm32l476vg;
 #[cfg(feature = "STM32L476VG")]
 pub use gpio::stm32l476vg::gpio::*;
+
+#[cfg(feature = "STM32L496AG")]
+pub mod stm32l496ag;
+#[cfg(feature = "STM32L496AG")]
+pub use gpio::stm32l496ag::gpio::*;

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -9,6 +9,8 @@ use ::marker::PhantomData;
 
 use hal::digital::OutputPin;
 
+use ::stm32l4x6;
+
 use rcc::AHB;
 
 /// Floating input (type state)
@@ -339,5 +341,43 @@ macro_rules! define_led {
     }
 }
 
+/// Opaque AFRL register
+pub struct AFRL<GPIO>(PhantomData<GPIO>);
+/// Opaque AFRH register
+pub struct AFRH<GPIO>(PhantomData<GPIO>);
+/// Opaque MODER register
+pub struct MODER<GPIO>(PhantomData<GPIO>);
+/// Opaque OTYPER register
+pub struct OTYPER<GPIO>(PhantomData<GPIO>);
+/// Opaque PUPDR register
+pub struct PUPDR<GPIO>(PhantomData<GPIO>);
+
+impl_parts!(
+    GPIOA, gpioa;
+    GPIOB, gpiob;
+    GPIOC, gpioc;
+    );
+
+//Each I/O pin (except PH3 for STM32L496xx/4A6xx devices) has a multiplexer with up to
+//sixteen alternate function inputs (AF0 to AF15) that can be configured through the
+//GPIOx_AFRL (for pin 0 to 7) and GPIOx_AFRH (for pin 8 to 15) registers
+//
+// The GPIO ports (and pins) enumerated here are exposed on all package variants of the STM32L4x6.
+// Larger chips have more pins, and so have additional definitions in their respective modules.
+impl_gpio!(A, GPIOA, gpioaen, gpioarst,
+           AFRL: [PA0, 0; PA1, 1; PA2, 2; PA3, 3; PA4, 4; PA5, 5; PA6, 6; PA7, 7;],
+           AFRH: [PA8, 8; PA9, 9; PA10, 10; PA11, 11; PA12, 12; PA13, 13; PA14, 14; PA15, 15; ]
+          );
+impl_gpio!(B, GPIOB, gpioben, gpiobrst,
+           AFRL: [PB0, 0; PB1, 1; PB2, 2; PB3, 3; PB4, 4; PB5, 5; PB6, 6; PB7, 7;],
+           AFRH: [PB8, 8; PB9, 9; PB10, 10; PB11, 11; PB12, 12; PB13, 13; PB14, 14; PB15, 15; ]
+          );
+impl_gpio!(C, GPIOC, gpiocen, gpiocrst,
+           AFRL: [PC0, 0; PC1, 1; PC2, 2; PC3, 3; PC4, 4; PC5, 5; PC6, 6; PC7, 7;],
+           AFRH: [PC8, 8; PC9, 9; PC10, 10; PC11, 11; PC12, 12; PC13, 13; PC14, 14; PC15, 15; ]
+          );
+
 #[cfg(feature = "STM32L476VG")]
 pub mod stm32l476vg;
+#[cfg(feature = "STM32L476VG")]
+pub use gpio::stm32l476vg::gpio::*;

--- a/src/gpio/stm32l476vg.rs
+++ b/src/gpio/stm32l476vg.rs
@@ -4,20 +4,7 @@ use ::stm32l4x6;
 
 use super::*;
 
-/// Opaque AFRL register
-pub struct AFRL<GPIO>(PhantomData<GPIO>);
-/// Opaque AFRH register
-pub struct AFRH<GPIO>(PhantomData<GPIO>);
-/// Opaque MODER register
-pub struct MODER<GPIO>(PhantomData<GPIO>);
-/// Opaque OTYPER register
-pub struct OTYPER<GPIO>(PhantomData<GPIO>);
-/// Opaque PUPDR register
-pub struct PUPDR<GPIO>(PhantomData<GPIO>);
 impl_parts!(
-    GPIOA, gpioa;
-    GPIOB, gpiob;
-    GPIOC, gpioc;
     //Next GPIOs are re-using gpioc modules
     GPIOD, gpioc;
     GPIOE, gpioc;
@@ -26,23 +13,8 @@ impl_parts!(
 
 /// Description of GPIOs and PINs
 pub mod gpio {
-    use super::*;
+    pub use super::*;
 
-    //Each I/O pin (except PH3 for STM32L496xx/4A6xx devices) has a multiplexer with up to
-    //sixteen alternate function inputs (AF0 to AF15) that can be configured through the
-    //GPIOx_AFRL (for pin 0 to 7) and GPIOx_AFRH (for pin 8 to 15) registers
-    impl_gpio!(A, GPIOA, gpioaen, gpioarst,
-               AFRL: [PA0, 0; PA1, 1; PA2, 2; PA3, 3; PA4, 4; PA5, 5; PA6, 6; PA7, 7;],
-               AFRH: [PA8, 8; PA9, 9; PA10, 10; PA11, 11; PA12, 12; PA13, 13; PA14, 14; PA15, 15; ]
-    );
-    impl_gpio!(B, GPIOB, gpioben, gpiobrst,
-               AFRL: [PB0, 0; PB1, 1; PB2, 2; PB3, 3; PB4, 4; PB5, 5; PB6, 6; PB7, 7;],
-               AFRH: [PB8, 8; PB9, 9; PB10, 10; PB11, 11; PB12, 12; PB13, 13; PB14, 14; PB15, 15; ]
-    );
-    impl_gpio!(C, GPIOC, gpiocen, gpiocrst,
-               AFRL: [PC0, 0; PC1, 1; PC2, 2; PC3, 3; PC4, 4; PC5, 5; PC6, 6; PC7, 7;],
-               AFRH: [PC8, 8; PC9, 9; PC10, 10; PC11, 11; PC12, 12; PC13, 13; PC14, 14; PC15, 15; ]
-    );
     impl_gpio!(D, GPIOD, gpioden, gpiodrst,
                AFRL: [PD0, 0; PD1, 1; PD2, 2; PD3, 3; PD4, 4; PD5, 5; PD6, 6; PD7, 7;],
                AFRH: [PD8, 8; PD9, 9; PD10, 10; PD11, 11; PD12, 12; PD13, 13; PD14, 14; PD15, 15; ]
@@ -51,7 +23,9 @@ pub mod gpio {
                AFRL: [PE0, 0; PE1, 1; PE2, 2; PE3, 3; PE4, 4; PE5, 5; PE6, 6; PE7, 7;],
                AFRH: [PE8, 8; PE9, 9; PE10, 10; PE11, 11; PE12, 12; PE13, 13; PE14, 14; PE15, 15; ]
     );
-    impl_gpio!(H, GPIOH, gpiohen, gpiohrst, AFRL: [PH0, 0; PH1, 1;]);
+    impl_gpio!(H, GPIOH, gpiohen, gpiohrst,
+               AFRL: [PH0, 0; PH1, 1;],
+               AFRH: []);
 }
 
 /// Description of LEDs

--- a/src/gpio/stm32l476vg.rs
+++ b/src/gpio/stm32l476vg.rs
@@ -1,15 +1,20 @@
 //! GPIO specific to STM32L476VG
+//!
+//! To use these definitions, enable the "STM32L476VG" feature, and include like so:
+//!
+//! ```rust
+//! use stm32l4x6_hal::gpio::stm32l476vg::gpio;
+//! ```
 
 use ::stm32l4x6;
 
 use super::*;
 
 impl_parts!(
-    //Next GPIOs are re-using gpioc modules
     GPIOD, gpioc;
     GPIOE, gpioc;
     GPIOH, gpioc;
-);
+    );
 
 /// Description of GPIOs and PINs
 pub mod gpio {

--- a/src/gpio/stm32l476vg.rs
+++ b/src/gpio/stm32l476vg.rs
@@ -18,7 +18,8 @@ impl_parts!(
 
 /// Description of GPIOs and PINs
 pub mod gpio {
-    pub use super::*;
+    use super::*;
+    pub use super::super::*;
 
     impl_gpio!(D, GPIOD, gpioden, gpiodrst,
                AFRL: [PD0, 0; PD1, 1; PD2, 2; PD3, 3; PD4, 4; PD5, 5; PD6, 6; PD7, 7;],

--- a/src/gpio/stm32l496ag.rs
+++ b/src/gpio/stm32l496ag.rs
@@ -1,0 +1,45 @@
+//! GPIO specific to STM32L496AG
+//!
+//! To use these definitions, enable the "STM32L496AG" feature, and include like so:
+//!
+//! ```rust
+//! use stm32l4x6_hal::gpio::stm32l496ag::gpio;
+//! ```
+
+use ::stm32l4x6;
+
+use super::*;
+
+impl_parts!(
+    GPIOD, gpioc;
+    GPIOE, gpioc;
+    GPIOF, gpioc;
+    GPIOG, gpioc;
+    GPIOH, gpioc;
+    );
+
+/// Description of GPIOs and PINs
+pub mod gpio {
+    pub use super::*;
+
+    impl_gpio!(D, GPIOD, gpioden, gpiodrst,
+               AFRL: [PD0, 0; PD1, 1; PD2, 2; PD3, 3; PD4, 4; PD5, 5; PD6, 6; PD7, 7;],
+               AFRH: [PD8, 8; PD9, 9; PD10, 10; PD11, 11; PD12, 12; PD13, 13; PD14, 14; PD15, 15; ]
+    );
+    impl_gpio!(E, GPIOE, gpioeen, gpioerst,
+               AFRL: [PE0, 0; PE1, 1; PE2, 2; PE3, 3; PE4, 4; PE5, 5; PE6, 6; PE7, 7;],
+               AFRH: [PE8, 8; PE9, 9; PE10, 10; PE11, 11; PE12, 12; PE13, 13; PE14, 14; PE15, 15; ]
+    );
+    impl_gpio!(F, GPIOF, gpiofen, gpiofrst,
+               AFRL: [PF0, 0; PF1, 1; PF2, 2; PF3, 3; PF4, 4; PF5, 5; PF6, 6; PF7, 7;],
+               AFRH: [PF8, 8; PF9, 9; PF10, 10; PF11, 11; PF12, 12; PF13, 13; PF14, 14; PF15, 15; ]
+    );
+    impl_gpio!(G, GPIOG,  gpiogen, gpiogrst,
+               AFRL: [PG0, 0; PG1, 1; PG2, 2; PG3, 3; PG4, 4; PG5, 5; PG6, 6; PG7, 7;],
+               AFRH: [PG8, 8; PG9, 9; PG10, 10; PG11, 11; PG12, 12; PG13, 13; PG14, 14; PG15, 15; ]
+    );
+    impl_gpio!(H, GPIOH, gpiohen, gpiohrst,
+               AFRL: [PH0, 0; PH1, 1; PH2, 2; PH4, 4; PH5, 5; PH6, 6; PH7, 7;],
+               AFRH: [PH8, 8; PH9, 9; PH10, 10; PH11, 11; PH12, 12; PH13, 13; PH14, 14; PH15, 15; ]
+    );
+}

--- a/src/gpio/stm32l496ag.rs
+++ b/src/gpio/stm32l496ag.rs
@@ -20,7 +20,8 @@ impl_parts!(
 
 /// Description of GPIOs and PINs
 pub mod gpio {
-    pub use super::*;
+    use super::*;
+    pub use super::super::*;
 
     impl_gpio!(D, GPIOD, gpioden, gpiodrst,
                AFRL: [PD0, 0; PD1, 1; PD2, 2; PD3, 3; PD4, 4; PD5, 5; PD6, 6; PD7, 7;],


### PR DESCRIPTION
This PR does two things:
* It moves GPIO ports common to all STM32L4x6 chips (that I've non-exhaustively checked) into the `gpio` module, which also reexports chip-specific GPIO definitions. This means you no longer need to `use hal::gpio::<chip>::gpio`, but you can just `use hal::gpio::GPIOE`.
* It adds support for the STM32L496AG chip (and tosses in a freebie LED definition for the STM32L496 Discovery board).

*Note!* This branch is cut from the `move-clocks-reference-crate` branch, and implicitly includes its content (until such time as that branch is merged).