### PR TITLE
Stm32l4x6 v0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 [dependencies]
 cortex-m = "0.4"
 nb = "0.1"
-stm32l4x6 = "0"
+stm32l4x6 = "0.5"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/DoumanAsh/stm32l4x6_hal"
 license = "Apache-2.0"
 
 [dependencies]
-cortex-m = "0.4"
+cortex-m = "0.5"
 nb = "0.1"
 stm32l4x6 = "0.5"
 
@@ -23,7 +23,7 @@ version = "1"
 
 [dependencies.cast]
 default-features = false
-version = "0"
+version = "0.2"
 
 [features]
 rt = ["stm32l4x6/rt"]

--- a/Xargo.toml
+++ b/Xargo.toml
@@ -1,6 +1,0 @@
-[dependencies.core]
-stage = 0
-
-[dependencies.compiler_builtins]
-features = ["mem"]
-stage = 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@
 //!
 //! [cortex-m-quickstart]: https://docs.rs/cortex-m-quickstart/~0.2.3
 
-#![feature(never_type)]
 #![no_std]
 
 extern crate cast;


### PR DESCRIPTION
Update to use stm32l4x6 version 0.5 and modify the crate to compile under beta and soon stable.