### PR TITLE
Correct AHB prescalar calculation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ script:
   - cargo check --target $TARGET
   - cargo check --target $TARGET --features STM32L476VG
   - cargo check --target $TARGET --features STM32L496AG
+  - cargo test
 
 after_script:
   - sh ci/build_docs.sh

--- a/src/rcc/clocking.rs
+++ b/src/rcc/clocking.rs
@@ -12,7 +12,9 @@
 //!
 //! To use them, compose them and feed them to, e.g., sysclk.
 //!
-//! ```rust
+//! ```rust, ignore
+//! use stm32l4x6_hal::rcc::clocking;
+//!
 //! let mut rcc = RCC.constrain();
 //! let msi_clk = clocking::MediumSpeedInternalRC::new(8_000_000, false);
 //! let sys_clk_src = clocking::SysClkSource::MSI(msi_clk);


### PR DESCRIPTION
It seems after 0b1011 math is getting bad

I.e.

1 << (0b1011 - 0b0111) == 16
1 << (0b1100 - 0b0111) == 32 while it should be 64
1 << (0b1111 - 0b0111) == 256 while it should be 512

APBx clocks prescalars are correct though
But still let's make code more simple

JFYI @thenewwazoo 